### PR TITLE
Fix unhandled errors in GIF fetch

### DIFF
--- a/api.js
+++ b/api.js
@@ -1,11 +1,21 @@
-const getImagen = async() =>{
-    const apiKey ='5duXGZopEkc8xiIiQP21p0mNOyNnYeZX';
-    const resp = await fetch(`https://api.giphy.com/v1/gifs/random?api_key=${apiKey}`);
-    const {data} = await resp.json(); // es necesario siempre destrcuturar la data
-    const {url} = data.images.original  // data.data.images.original codigo aternario si no se destructura la data
-    const img = document.createElement('img')
-    img.src = url
-    document.body.append(img)
-}
+const getImagen = async () => {
+  const apiKey = '5duXGZopEkc8xiIiQP21p0mNOyNnYeZX';
 
-getImagen()
+  try {
+    const resp = await fetch(`https://api.giphy.com/v1/gifs/random?api_key=${apiKey}`);
+    if (!resp.ok) {
+      throw new Error(`HTTP error! status: ${resp.status}`);
+    }
+
+    const { data } = await resp.json(); // es necesario siempre desestructurar la data
+    const { url } = data.images.original; // data.data.images.original si no se desestructura la data
+
+    const img = document.createElement('img');
+    img.src = url;
+    document.body.append(img);
+  } catch (error) {
+    console.error('Error fetching image:', error);
+  }
+};
+
+getImagen();


### PR DESCRIPTION
## Summary
- add error handling for the asynchronous fetch to GIPHY

## Testing
- `node api.js` *(fails to fetch due to network restrictions but logs error instead of crashing)*

------
https://chatgpt.com/codex/tasks/task_e_683f924269e8832fa920e9b3fc0e7849